### PR TITLE
Static folder example setting incorrectly used :nginx_root_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ set :nginx_root_path, "/etc/nginx"
 
 # Path where to look for static files
 # default value: "public"
-set :nginx_root_path, "my_static_folder"
+set :nginx_static_dir, "my_static_folder"
 
 # Path where nginx available site are stored
 # default value: "sites-available"


### PR DESCRIPTION
Changed :nginx_root_path to :nginx_static_dir for the example static dir config. 
