### PR TITLE
Added switchable nginx service path

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Configurable options (copy into deploy.rb), shown here with examples:
 # No default vaue
 set :nginx_domains, "foo.bar.com"
 
+# nginx service script
+# Defaults to using the 'service' convinience script.
+# You might prefer using the init.d instead depending on sudo privilages.
+# default value: "service nginx"
+set :nginx_service_path, "/etc/init.d/nginx"
+
 # Roles the deploy nginx site on,
 # default value: :web
 set :nginx_roles, :web

--- a/lib/capistrano/tasks/nginx.rake
+++ b/lib/capistrano/tasks/nginx.rake
@@ -1,5 +1,6 @@
 namespace :load do
   task :defaults do
+    set :nginx_service_path, -> { 'service nginx' }
     set :nginx_roles, -> { :web }
     set :nginx_log_path, -> { "#{shared_path}/log" }
     set :nginx_root_path, -> { "/etc/nginx" }
@@ -23,9 +24,10 @@ namespace :nginx do
   %w[start stop restart reload].each do |command|
     desc "#{command.capitalize} nginx service"
     task command do
+      nginx_service = fetch(:nginx_service_path)
       on release_roles fetch(:nginx_roles) do
-        if command === 'stop' || (test "sudo nginx -t")
-          execute :sudo, "service nginx #{command}"
+        if command === 'stop' || (test "[ $(sudo #{nginx_service} configtest | grep -c 'fail') -eq 0 ]")
+          execute :sudo, "#{nginx_service} #{command}"
         end
       end
     end


### PR DESCRIPTION
Added switchable nginx service path for users who do not allow passwordless access to the full service scripts for their deployment user, but rather limits passwordless sudo access to the init.d/nginx script. Also had to refactor the nginx configuration test as well since it was running (/usr/sbin/)nginx directly.
