### PR TITLE
":gzip_static" task to compress JS and CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ cap nginx:site:add                 # Creates the site configuration and upload i
 cap nginx:site:disable             # Disables the site removing the symbolic link located in the enabled folder
 cap nginx:site:enable              # Enables the site creating a symbolic link into the enabled folder
 cap nginx:site:remove              # Removes the site removing the configuration file from the available folder
+cap nginx:gzip_static              # Compress all js and css files in :nginx_static_dir with gzip
 ```
 
 Configurable options (copy into deploy.rb), shown here with examples:

--- a/lib/capistrano/tasks/nginx.rake
+++ b/lib/capistrano/tasks/nginx.rake
@@ -43,6 +43,15 @@ namespace :nginx do
     end
   end
 
+  desc 'Compress JS and CSS with gzip'
+  task :gzip_static => ['nginx:load_vars'] do
+    on release_roles fetch(:nginx_roles) do
+      within release_path do
+        execute :find, "'#{fetch(:nginx_static_dir)}' -type f -name '*.js' -o -name '*.css' -exec gzip -v -9 -f -k {} \\;"
+      end
+    end
+  end
+
   namespace :site do
     desc 'Creates the site configuration and upload it to the available folder'
     task :add => ['nginx:load_vars'] do


### PR DESCRIPTION
For use with nginx `gzip_static`-feature

Replaces #4 
- Rebased on `master`
- USes (now existing) variable `nginx_static_dir` instead of a new one.
