### PR TITLE
feat(): adds timeout configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ set :nginx_ssl_certificate_key, 'my-domain.key'
 # default value: "/etc/ssl/private"
 set :nginx_ssl_certificate_key_path, "#{shared_path}/ssl/private"
 
+# You can set a timeout value in seconds
+# nginx's default is 30 seconds
+set :nginx_read_timeout, 30
+
 # Whether you want to server an application through a proxy pass
 # default value: true
 set :app_server, true

--- a/templates/nginx.conf.erb
+++ b/templates/nginx.conf.erb
@@ -61,6 +61,9 @@ server {
   <% if fetch(:nginx_use_ssl) %>
     proxy_set_header X-Forwarded-Proto https;
   <% end %>
+  <% if fetch(:nginx_read_timeout) %>
+    proxy_read_timeout <%= fetch(:nginx_read_timeout) %>;
+  <% end %>
     proxy_redirect off;
     proxy_pass http://<%= fetch(:application) %>-app-server;
   }


### PR DESCRIPTION
I've encountered several times the need to configure a longer timeout when the server processes Excel files or performs similar tasks that require longer waiting times. Even though longer timeouts are not the best solution, most of the times it is the preferred way to go as it is a simple and straightforward way to solve the issue. I think this configuration should be available as a variable.. i propose here "nginx_read_timeout"