### PR TITLE
Updated to allow easy customisation of nginx paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,17 +75,13 @@ set :nginx_roles, :web
 # default value:  "#{shared_path}/log"
 # set :nginx_log_path, "#{shared_path}/log"
 
-# Path where nginx is installed
-# default value: "/etc/nginx"
-set :nginx_root_path, "/etc/nginx"
-
 # Path where to look for static files
 # default value: "public"
 set :nginx_static_dir, "my_static_folder"
 
 # Path where nginx available site are stored
 # default value: "sites-available"
-set :nginx_sites_available_dir, "sites-available"
+set :nginx_sites_available_dir, "/etc/nginx/sites-available"
 
 # Name of file stored in site-enabled/available
 # default value: "#{fetch :application}"
@@ -93,7 +89,7 @@ set :nginx_application_name, "#{fetch :application}-#{fetch :stage}"
 
 # Path where nginx available site are stored
 # default value: "sites-enabled"
-set :nginx_sites_enabled_dir, "sites-enabled"
+set :nginx_sites_enabled_dir, "/etc/nginx/sites-enabled"
 
 # Path to look for custom config template
 # `:default` will use the bundled nginx template

--- a/lib/capistrano/tasks/nginx.rake
+++ b/lib/capistrano/tasks/nginx.rake
@@ -3,12 +3,11 @@ namespace :load do
     set :nginx_sudo_paths,          -> { [:nginx_log_path, :nginx_sites_enabled_dir, :nginx_sites_available_dir] }
     set :nginx_sudo_tasks,          -> { ['nginx:start', 'nginx:stop', 'nginx:restart', 'nginx:reload', 'nginx:configtest', 'nginx:site:add', 'nginx:site:disable', 'nginx:site:enable', 'nginx:site:remove' ] }
     set :nginx_log_path,            -> { "#{shared_path}/log" }
-    set :nginx_root_path,           -> { "/etc/nginx" }
     set :nginx_service_path,        -> { 'service nginx' }
     set :nginx_static_dir,          -> { "public" }
-    set :nginx_sites_enabled_dir,   -> { "sites-enabled" }
-    set :nginx_sites_available_dir, -> { "sites-available" }
     set :nginx_application_name,    -> { fetch(:application) }
+    set :nginx_sites_enabled_dir,   -> { "/etc/nginx/sites-enabled" }
+    set :nginx_sites_available_dir, -> { "/etc/nginx/sites-available" }
     set :nginx_roles,               -> { :web }
     set :nginx_template,            -> { :default }
     set :nginx_use_ssl,             -> { false }
@@ -43,8 +42,8 @@ namespace :nginx do
   end
 
   task :load_vars do
-    set :sites_available,       -> { File.join(fetch(:nginx_root_path), fetch(:nginx_sites_available_dir)) }
-    set :sites_enabled,         -> { File.join(fetch(:nginx_root_path), fetch(:nginx_sites_enabled_dir)) }
+    set :sites_available,       -> { fetch(:nginx_sites_available_dir) }
+    set :sites_enabled,         -> { fetch(:nginx_sites_enabled_dir) }
     set :enabled_application,   -> { File.join(fetch(:sites_enabled),   fetch(:nginx_application_name)) }
     set :available_application, -> { File.join(fetch(:sites_available), fetch(:nginx_application_name)) }
   end


### PR DESCRIPTION
Implements proposed solution in issue #21. 

As mentioned in the issue I have removed `nginx_root_dir` and updated `nginx_sites_enabled_dir` and `nginx_sites_available_dir` to allow easy and clear customisation of paths. 

I've not changed the default sudo options for this as this will still be required given the default locations.