### PR TITLE
Added X-Forwarded-Ssl header to fix invalid CSRF error

### DIFF
--- a/templates/nginx.conf.erb
+++ b/templates/nginx.conf.erb
@@ -70,6 +70,7 @@ server {
     proxy_set_header Host $http_host;
   <% if fetch(:nginx_use_ssl) %>
     proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header X-Forwarded-Ssl on;
   <% end %>
   <% if fetch(:nginx_read_timeout) %>
     proxy_read_timeout <%= fetch(:nginx_read_timeout) %>;


### PR DESCRIPTION
In Rails 5, when using Nginx, Puma and SSL, submitting any form causes a CSRF error. This fixes it.