### PR TITLE
Fixes proxy_set_header X-Forwarded-Proto duplication in template

### DIFF
--- a/templates/nginx.conf.erb
+++ b/templates/nginx.conf.erb
@@ -66,11 +66,12 @@ server {
   location @<%= fetch(:application) %>-app-server {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-FORWARDED_PROTO http;
     proxy_set_header Host $http_host;
   <% if fetch(:nginx_use_ssl) %>
     proxy_set_header X-Forwarded-Proto https;
     proxy_set_header X-Forwarded-Ssl on;
+  <% else %>
+    proxy_set_header X-Forwarded-Proto http;
   <% end %>
   <% if fetch(:nginx_read_timeout) %>
     proxy_read_timeout <%= fetch(:nginx_read_timeout) %>;


### PR DESCRIPTION
On https deployment with nginx_use_ssl set to true,
the header X-Forwarded-Proto would be declared twice
once for http and once for https.

This caused a bug in Sinatra where the crafted url after a submit would be on port 80 instead of 443.

Fixes issue #33