### PR TITLE
Add nginx prefix to #use_sudo? method

### DIFF
--- a/lib/capistrano/tasks/nginx.rake
+++ b/lib/capistrano/tasks/nginx.rake
@@ -24,19 +24,19 @@ namespace :nginx do
   # prepend :sudo to list if arguments if :key is in :nginx_use_sudo_for list
   def add_sudo_if_required argument_list, *keys
     keys.each do | key |
-      if use_sudo? key
+      if nginx_use_sudo? key
         argument_list.unshift(:sudo)
         break
       end
     end
   end
 
-  def use_sudo? key
+  def nginx_use_sudo? key
     return (fetch(:nginx_sudo_tasks).include?(key) || fetch(:nginx_sudo_paths).include?(key))
   end
 
   def valid_nginx_config?
-    test_sudo = use_sudo?('nginx:configtest') ? 'sudo ' : ''
+    test_sudo = nginx_use_sudo?('nginx:configtest') ? 'sudo ' : ''
     nginx_service = fetch(:nginx_service_path)
     test "[ $(#{test_sudo}#{nginx_service} configtest | grep -c 'fail') -eq 0 ]"
   end


### PR DESCRIPTION
I'm using `capistrano3-nginx` with `capistrano/sidekiq/monit` and there is collision for `use_sudo?` method name. There is the same method without args:
[https://github.com/seuros/capistrano-sidekiq/blob/master/lib/capistrano/tasks/monit.rake#L136](url)

Error backtrace:

```
ArgumentError: wrong number of arguments (given 1, expected 0)
.rvm/gems/ruby-2.3.3/gems/capistrano-sidekiq-0.10.0/lib/capistrano/tasks/monit.rake:136:in use_sudo?'
.rvm/gems/ruby-2.3.3/gems/capistrano3-nginx-2.1.6/lib/capistrano/tasks/nginx.rake:27:in block in add_sudo_if_required'
.rvm/gems/ruby-2.3.3/gems/capistrano3-nginx-2.1.6/lib/capistrano/tasks/nginx.rake:26:in each'
.rvm/gems/ruby-2.3.3/gems/capistrano3-nginx-2.1.6/lib/capistrano/tasks/nginx.rake:26:in add_sudo_if_required'
.rvm/gems/ruby-2.3.3/gems/capistrano3-nginx-2.1.6/lib/capistrano/tasks/nginx.rake:86:in block (3 levels) in <top (required)>'
```

