### PR TITLE
added info regarding newer fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Require in `Capfile` to use the default task:
 require 'capistrano/nginx'
 ```
 
-If you are using the newer maintained fork, your `Capfile` will also need need: 
+If you are using the newer maintained fork (see above), your `Capfile` will also need need: 
 
 ```ruby
-install install_plugin Capistrano::Nginx
+install_plugin Capistrano::Nginx
 ```
 
 You will get the following tasks

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Require in `Capfile` to use the default task:
 require 'capistrano/nginx'
 ```
 
+If you are using the newer maintained fork, your `Capfile` will also need need: 
+
+```ruby
+install install_plugin Capistrano::Nginx
+```
+
 You will get the following tasks
 
 ```ruby


### PR DESCRIPTION
I know this isn't great, but I didn't notice the information at the top about the newer fork. Having this line here would have saved me 45 minutes of head scratching as this repo is the first that shows up in google. Alternatively, the notice about this repo not being the most up to date could be made a lot more noticeable!

Thanks!